### PR TITLE
feat(과제): 피드백 및 베스트 과제 기능 추가

### DIFF
--- a/packages/app/src/features/assignments/service.ts
+++ b/packages/app/src/features/assignments/service.ts
@@ -13,12 +13,24 @@ type AssignmentPath = (typeof assignments)[number]["path"];
 
 export const fetchAssignments = async (path: AssignmentPath): Promise<Assignment[]> => {
   const { default: data } = await import(`../../../../../docs/data/${path}/pulls.json`);
-  return data.map((item: GithubPullRequest) => ({
-    ...pick(item, ["id", "user", "title", "body"]),
-    url: item.html_url,
-    createdAt: new Date(item.created_at),
-    updatedAt: new Date(item.updated_at),
-  }));
+
+  const { default: userAssignmentInfos } = await import(`../../../../../docs/data/user-assignment-infos.json`);
+
+  return data.map((item: GithubPullRequest) => {
+    const userAssignmentInfo = userAssignmentInfos.filter((info) => info.assignment.url === item.html_url);
+
+    const feedback = userAssignmentInfo.map((info) => info.feedback).join("");
+    const isBest = userAssignmentInfo.some((info) => info.theBest);
+
+    return {
+      ...pick(item, ["id", "user", "title", "body"]),
+      url: item.html_url,
+      feedback,
+      isBest,
+      createdAt: new Date(item.created_at),
+      updatedAt: new Date(item.updated_at),
+    };
+  });
 };
 
 export const fetchAllAssignments = async () => {

--- a/packages/app/src/features/assignments/types.ts
+++ b/packages/app/src/features/assignments/types.ts
@@ -4,4 +4,6 @@ export type Assignment = Pick<GithubPullRequest, "id" | "user" | "title" | "body
   createdAt: Date;
   updatedAt: Date;
   url: string;
+  feedback: string;
+  isBest: boolean;
 };

--- a/packages/app/src/pages/assignment/detail/AssignmentDetail.tsx
+++ b/packages/app/src/pages/assignment/detail/AssignmentDetail.tsx
@@ -10,6 +10,7 @@ const AssignmentDetailProvider = ({ children }: PropsWithChildren) => {
   const { assignmentId = "" } = useParams<{ assignmentId: string }>();
   const userId = useUserIdByParam();
   const { data: assignment } = useAssignmentById(userId, assignmentId);
+
   const title = assignment ? (
     <>
       <Link to={`/@${assignment.user.login}/`}>{assignment.user.login} 님의 상세페이지</Link> ＞ {assignment.title}
@@ -84,6 +85,8 @@ export const AssignmentDetail = Object.assign(
             }}
           />
         </div>
+
+        {/* TODO: Feedback Design 추가 */}
       </div>
     );
   },

--- a/packages/app/src/pages/user/User.tsx
+++ b/packages/app/src/pages/user/User.tsx
@@ -31,7 +31,7 @@ const UserProfile = ({ id, image, link }: GithubUser) => {
   );
 };
 
-const AssignmentCard = ({ id, title, url, createdAt }: Assignment) => {
+const AssignmentCard = ({ id, title, url, createdAt, isBest }: Assignment) => {
   return (
     <Card className="hover:shadow-glow transition-all duration-300 cursor-pointer group bg-card border border-border">
       <Link to={`./assignment/${id}/`} className="block">
@@ -39,7 +39,7 @@ const AssignmentCard = ({ id, title, url, createdAt }: Assignment) => {
           <div className="flex flex-col space-y-3">
             {/* 과제 제목 */}
             <h3 className="text-lg font-semibold text-white group-hover:text-orange-300 transition-colors leading-tight">
-              {title}
+              {title} {isBest && <span className="text-orange-400">👍</span>}
             </h3>
 
             {/* 메타 정보 */}


### PR DESCRIPTION
## 링크된 이슈
https://github.com/hanghae-plus/front_6th/issues/7

## 변경사항
### 🎯 주요 기능 추가
- **피드백 **: 과제에 대한 피드백 정보를 표시하는 기능 추가
- **베스트 과제 표시**: 우수한 과제를 구분할 수 있는 베스트 플래그 추가

#### 1. 과제 데이터 구조 개선
- `Assignment` 타입에 `feedback`과 `isBest` 필드 추가
- 사용자 과제 정보(`user-assignment-infos.json`)와 과제 데이터 통합

#### 2. 과제 서비스 강화
- `assignments/service.ts`: 사용자 피드백 데이터 로드 기능 추가
- 과제 목록 조회 시 피드백 및 베스트 정보 함께 제공

#### 3. UI 컴포넌트 업데이트
- `AssignmentDetail.tsx`: 과제 상세 페이지에서 피드백 및 베스트 표시
- `User.tsx`: 사용자 페이지에서 과제별 피드백 정보 표시


## 질문
#### 1. 데이터 맵핑 
❤️준일님이 말씀하신 잘못넣는 사람들 데이터를 보고 맵핑 가능할지 보려고 했는데 
지금 크롤링된 데이터를 봤을 때 전부 pr url이더라구요...?
그래서 일단 url로만 매칭을 시켰습니다.
그리고 또 생각이 든게 잘못넣는 사람은 그 사람 잘못아닌가! 
보장해주는 것은 고도화 때 생각해도 되지 않을까? 라는 생각도 해보았습니다!

❤️준일님의 의견 부탁드리겠습니다!

#### 2. 피드백 디자인
피드백 데이터를 어떻게 보여주는게 좋을까요?
위에 pr작성한거 아래에 그대로 markdown으로 넣어봤더니 pr, feedback이 섞이면서 가독성이 안좋더라구요.
토글 같은걸로 넣을까 싶은데 ❤️준일님, 영서님 의견 부탁드립니다! 
